### PR TITLE
[panda_eus] Make :gripper method work & enable to get gripper status while moving

### DIFF
--- a/jsk_panda_robot/panda_eus/euslisp/franka-common-interface.l
+++ b/jsk_panda_robot/panda_eus/euslisp/franka-common-interface.l
@@ -274,7 +274,8 @@ Details: `ErrorRecoveryAction` part of https://frankaemika.github.io/docs/franka
        (dolist (a arms)
          (setq wait-res
                (and (send self :send-gripper-action-method a actions :wait-for-result)
-                    wait-res))))
+                    wait-res)))
+       (send self :spin-once))
      (if (not wait-res)
        (progn
          (setq wait-res t)
@@ -316,9 +317,9 @@ Details: `StopAction` part of https://frankaemika.github.io/docs/franka_ros.html
          :send-gripper-stop-action gripper-stop-actions arm wait)
    )
   (:get-stop-gripper-result
-   (arm)
+   (arm &key (wait t))
    "Return result of :stop-gripper (`franka_gripper::StopActionResult`)"
-   (send self :gripper-action-postprocess arm gripper-stop-actions t)
+   (send self :gripper-action-postprocess arm gripper-stop-actions wait)
    )
   (:homing-gripper
    (arm &key (wait nil))
@@ -331,9 +332,9 @@ Details: `HomingAction` part of https://frankaemika.github.io/docs/franka_ros.ht
            :send-gripper-homing-action gripper-homing-actions arm wait)
      ))
   (:get-homing-gripper-result
-   (arm)
+   (arm &key (wait t))
    "Return result of :homing-gripper (`franka_gripper::HomingActionResult`)"
-   (send self :gripper-action-postprocess arm gripper-homing-actions t)
+   (send self :gripper-action-postprocess arm gripper-homing-actions wait)
    )
   (:gripper
    (&rest args)
@@ -396,9 +397,9 @@ Details: `GraspAction` part of https://frankaemika.github.io/docs/franka_ros.htm
            effort :inner inner :outer outer)
      ))
   (:get-start-grasp-result
-   (arm)
+   (arm &key (wait t))
    "Return result of :start-grasp (`franka_gripper::GraspActionResult`)"
-   (send self :gripper-action-postprocess arm gripper-grasp-actions t)
+   (send self :gripper-action-postprocess arm gripper-grasp-actions wait)
    )
   (:stop-grasp
    (arm &key (wait nil) (width 0.08))
@@ -406,9 +407,9 @@ Details: `GraspAction` part of https://frankaemika.github.io/docs/franka_ros.htm
    (send self :move-gripper arm width :tm 500 :wait wait)
    )
   (:get-stop-grasp-result
-   (arm)
+   (arm &key (wait t))
    "Return result of :stop-gripper (`franka_gripper::MoveActionResult`)"
-   (send self :get-move-gripper-result arm)
+   (send self :get-move-gripper-result arm :wait wait)
    )
   (:move-gripper
    (arm width &key (tm 500) (wait nil))
@@ -421,9 +422,9 @@ Details: `MoveAction` part of https://frankaemika.github.io/docs/franka_ros.html
            :send-gripper-move-action gripper-move-actions arm wait width tm)
      ))
   (:get-move-gripper-result
-   (arm)
+   (arm &key (wait t))
    "Return result of :move-gripper (`franka_gripper::MoveActionResult`)"
-   (send self :gripper-action-postprocess arm gripper-move-actions t)
+   (send self :gripper-action-postprocess arm gripper-move-actions wait)
    )
   )
 

--- a/jsk_panda_robot/panda_eus/euslisp/franka-common-interface.l
+++ b/jsk_panda_robot/panda_eus/euslisp/franka-common-interface.l
@@ -264,8 +264,14 @@ Details: `ErrorRecoveryAction` part of https://frankaemika.github.io/docs/franka
      ))
   (:send-gripper-action-method
    (arm actions method &rest args)
-   (let ((action (gethash (send self :expand-arm-alias arm) actions)))
-     (if action (send* action method args) nil))
+   (case arm
+     (:arms
+       (mapcar #'(lambda (a)
+                   (send self :send-gripper-action-method a actions method))
+               (send self :arm2arms arm)))
+     (t
+       (let ((action (gethash (send self :expand-arm-alias arm) actions)))
+         (if action (send* action method args) nil))))
    )
   (:gripper-action-postprocess
    (arm actions wait)
@@ -289,13 +295,7 @@ Details: `ErrorRecoveryAction` part of https://frankaemika.github.io/docs/franka
                (setq wait-res nil))))
          (if (not wait-res)
            (return-from :gripper-action-postprocess nil))))
-     (case arm
-       (:arms
-         (mapcar #'(lambda (a)
-                     (send self :send-gripper-action-method a actions :get-result))
-                 arms))
-       (t
-         (send self :send-gripper-action-method arm actions :get-result)))
+     (send self :send-gripper-action-method arm actions :get-result)
      ))
   (:gripper-method-helper
    (action-sender actions arm wait)
@@ -316,6 +316,12 @@ Details: `StopAction` part of https://frankaemika.github.io/docs/franka_ros.html
    (send self :gripper-method-helper
          :send-gripper-stop-action gripper-stop-actions arm wait)
    )
+  (:get-stop-gripper-status
+   (arm)
+   "Return status of :stop-gripper (`status` of `actionlib_msgs::GoalStatus`)"
+   (send self :spin-once)
+   (send self :send-gripper-action-method arm gripper-stop-actions :get-state)
+   )
   (:get-stop-gripper-result
    (arm &key (wait t))
    "Return result of :stop-gripper (`franka_gripper::StopActionResult`)"
@@ -331,6 +337,12 @@ Details: `HomingAction` part of https://frankaemika.github.io/docs/franka_ros.ht
      (send self :gripper-method-helper
            :send-gripper-homing-action gripper-homing-actions arm wait)
      ))
+  (:get-homing-gripper-status
+   (arm)
+   "Return status of :homing-gripper (`status` of `actionlib_msgs::GoalStatus`)"
+   (send self :spin-once)
+   (send self :send-gripper-action-method arm gripper-homing-actions :get-state)
+   )
   (:get-homing-gripper-result
    (arm &key (wait t))
    "Return result of :homing-gripper (`franka_gripper::HomingActionResult`)"
@@ -396,6 +408,12 @@ Details: `GraspAction` part of https://frankaemika.github.io/docs/franka_ros.htm
            :send-gripper-grasp-action gripper-grasp-actions arm wait width tm
            effort :inner inner :outer outer)
      ))
+  (:get-start-grasp-status
+   (arm)
+   "Return status of :start-grasp (`status` of `actionlib_msgs::GoalStatus`)"
+   (send self :spin-once)
+   (send self :send-gripper-action-method arm gripper-grasp-actions :get-state)
+   )
   (:get-start-grasp-result
    (arm &key (wait t))
    "Return result of :start-grasp (`franka_gripper::GraspActionResult`)"
@@ -406,9 +424,14 @@ Details: `GraspAction` part of https://frankaemika.github.io/docs/franka_ros.htm
    "Open the gripper to the target `width` [m]"
    (send self :move-gripper arm width :tm 500 :wait wait)
    )
+  (:get-stop-grasp-status
+   (arm)
+   "Return status of :stop-grasp (`status` of `actionlib_msgs::GoalStatus`)"
+   (send self :get-move-gripper-status arm)
+   )
   (:get-stop-grasp-result
    (arm &key (wait t))
-   "Return result of :stop-gripper (`franka_gripper::MoveActionResult`)"
+   "Return result of :stop-grasp (`franka_gripper::MoveActionResult`)"
    (send self :get-move-gripper-result arm :wait wait)
    )
   (:move-gripper
@@ -421,6 +444,12 @@ Details: `MoveAction` part of https://frankaemika.github.io/docs/franka_ros.html
      (send self :gripper-method-with-width-helper
            :send-gripper-move-action gripper-move-actions arm wait width tm)
      ))
+  (:get-move-gripper-status
+   (arm)
+   "Return status of :move-gripper (`status` of `actionlib_msgs::GoalStatus`)"
+   (send self :spin-once)
+   (send self :send-gripper-action-method arm gripper-move-actions :get-state)
+   )
   (:get-move-gripper-result
    (arm &key (wait t))
    "Return result of :move-gripper (`franka_gripper::MoveActionResult`)"

--- a/jsk_panda_robot/panda_eus/models/dual_panda.urdf.xacro
+++ b/jsk_panda_robot/panda_eus/models/dual_panda.urdf.xacro
@@ -109,17 +109,17 @@
   <link name="$(arg arm_id_1)_end_effector" >
   </link>
   <joint name="$(arg arm_id_1)_end_effector_joint" type="fixed">
-    <parent link="$(arg arm_id_1)_hand_tcp"/>
+    <parent link="$(arg arm_id_1)_hand"/>
     <child link="$(arg arm_id_1)_end_effector"/>
-    <origin xyz="0 0 0" rpy="0 -1.570796327 0"/>
+    <origin xyz="0 0 0.1034" rpy="0 -1.570796327 0"/>
   </joint>
 
   <link name="$(arg arm_id_2)_end_effector" >
   </link>
   <joint name="$(arg arm_id_2)_end_effector_joint" type="fixed">
-    <parent link="$(arg arm_id_2)_hand_tcp"/>
+    <parent link="$(arg arm_id_2)_hand"/>
     <child link="$(arg arm_id_2)_end_effector"/>
-    <origin xyz="0 0 0" rpy="0 -1.570796327 0"/>
+    <origin xyz="0 0 0.1034" rpy="0 -1.570796327 0"/>
   </joint>
 
 </robot>

--- a/jsk_panda_robot/panda_eus/models/dual_panda.yaml
+++ b/jsk_panda_robot/panda_eus/models/dual_panda.yaml
@@ -20,12 +20,12 @@ larm:
 #  - pan_tilt_JOINT1 : head-neck-p
 
 rarm-end-coords:
-  parent: rarm_hand_tcp
-  translate: [0, 0, 0]
+  parent: rarm_hand  # If rarm_hand_tcp is used to delete the following translation, (send *dual_panda* :rarm :gripper :joint-list) does not include finger joints
+  translate: [0, 0, 0.1034]  # https://github.com/frankaemika/franka_ros/blob/0.10.1/franka_description/robots/common/franka_robot.xacro#L8
   rotate : [0, -1, 0, 90]
 larm-end-coords:
-  parent: larm_hand_tcp
-  translate: [0, 0, 0]
+  parent: larm_hand  # If larm_hand_tcp is used to delete the following translation, (send *dual_panda* :larm :gripper :joint-list) does not include finger joints
+  translate: [0, 0, 0.1034]  # https://github.com/frankaemika/franka_ros/blob/0.10.1/franka_description/robots/common/franka_robot.xacro#L8
   rotate : [0, -1, 0, 90]
 
 angle-vector:

--- a/jsk_panda_robot/panda_eus/models/panda.yaml
+++ b/jsk_panda_robot/panda_eus/models/panda.yaml
@@ -8,8 +8,8 @@ rarm:
   - panda_joint7 : rarm-wrist-y
 
 rarm-end-coords:
-  parent: panda_hand_tcp
-  translate: [0, 0, 0]
+  parent: panda_hand  # If panda_hand_tcp is used to delete the following translation, (send *panda* :rarm :gripper :joint-list) does not include finger joints
+  translate: [0, 0, 0.1034]  # https://github.com/frankaemika/franka_ros/blob/0.10.1/franka_description/robots/common/franka_robot.xacro#L8
   rotate : [0, -1, 0, 90]
 
 angle-vector:


### PR DESCRIPTION
https://github.com/yuki-asano/jsk_robot/pull/3 の副作用として、`(send *panda* :rarm :gripper :joint-list)`の返り値に指ジョイントが含まれないようになり、グリッパの指の現在位置を知る`(send *ri* :gripper :rarm :position)`が常に0を返すようになってしまいました。
`(send *ri* :stop-grasp :rarm :width 0.1)`とかでは、現在位置から目標位置までの距離と目標所要時間から指の速度を計算して指令しているので、この速度が非常に小さくなり、ゆっくり動くようになってしまっていました。

この問題を解消するため、`end-coords`の親リンクとして`*_hand_tcp`を使うのをやめ、`*_hand`を使うようにしました。
yamlにURDF由来の数字が出てきてしまって二重管理になるのですが、URDF上の値をそのままコピーするだけで足し算とかは必要ないなので、まだセーフだと考えています。

`end-coords`の位置が以前と変化していないこと、`(send *ri* :gripper :rarm/:larm :position)`が機能することは確認しました。

また、`(send *ri* :get-start-grasp-result :rarm :wait nil)`などとすると、現在のグリッパの動きを待つことなく前回の動作の結果を返すようにしました。
ただし、`:wait nil`の場合は、`:start-grasp`を一回でも呼んだ後でないと、https://github.com/yuki-asano/jsk_robot/pull/1#discussion_r1212576855 と同じ読みにくいエラーが出てしまいます。
これは解決が難しく、エラーメッセージを読みやすくするのはあくまでオプショナルだと考えてスキップしました。

さらに、`(send *ri* :get-start-grasp-status :rarm)`などとすると、最後に指令した`:start-grasp`の動作の現在の状態を返すようにしました。
`actionlib_msgs::GoalStatus`の`status`の値が返ってくるので、現在も動作を実行中かどうか、動作が正常終了したのかどうかなどを判定できます。